### PR TITLE
Remove duplicate dashboard redirect on login

### DIFF
--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -33,8 +33,7 @@ const handleLogin = async (e: React.FormEvent) => {
 
   try {
     setSubmitting(true);
-    await login(email, password);                 // faz o sign-in e atualiza o estado
-    navigate('/dashboard', { replace: true });   // empurra pro redirector por role
+    await login(email, password);                 // faz o sign-in, atualiza o estado e redireciona
   } catch (err: any) {
     console.error(err);                           // o AuthProvider já povoa o erro
   } finally {


### PR DESCRIPTION
## Summary
- rely on auth login to redirect to dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2174951948330b323c2f00a31fe73