### PR TITLE
fix: avoid login hang when backend unavailable

### DIFF
--- a/auth.tsx
+++ b/auth.tsx
@@ -176,10 +176,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         }
       } catch (_) { /* ignore ensure errors */ }
 
-      const ok = await fetchBackendUser();
-      if (ok) {
-        navigate('/dashboard', { replace: true });
-      }
+      // Dispara a busca pelo perfil no backend sem bloquear a navegação.
+      // Qualquer atualização de estado será tratada por `fetchBackendUser`/onAuthStateChange.
+      fetchBackendUser().catch(() => {/* handled internamente */});
+      navigate('/dashboard', { replace: true });
     } catch (err: any) {
       console.error('Login failed', err);
       setError(mapAuthError(err?.message));


### PR DESCRIPTION
## Summary
- prevent login from waiting on backend profile fetch

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b21ef40aa08330aa202250f4b895d7