### PR TITLE
feat: add auth navigation pages and dashboard router

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,21 +2,23 @@ import { HashRouter, Routes, Route } from 'react-router-dom';
 import { AuthProvider } from './auth';
 import RouteGuard from './components/RouteGuard';
 import LoginPage from './pages/Login';
-import Dashboard from './pages/Dashboard';
+import DashboardRouter from './pages/DashboardRouter';
 import RegisterPage from './pages/Register';
 import UpdatePasswordPage from './pages/UpdatePassword';
+import ForgotPasswordPage from './pages/ForgotPassword';
 
 const AppContent = () => {
     return (
         <Routes>
             <Route path="/login" element={<LoginPage />} />
             <Route path="/register" element={<RegisterPage />} />
+            <Route path="/forgot-password" element={<ForgotPasswordPage />} />
             <Route path="/update-password" element={<UpdatePasswordPage />} />
             <Route
                 path="/dashboard/*"
                 element={
                     <RouteGuard>
-                        <Dashboard />
+                        <DashboardRouter />
                     </RouteGuard>
                 }
             />

--- a/pages/DashboardRouter.tsx
+++ b/pages/DashboardRouter.tsx
@@ -41,7 +41,7 @@ const ProtectedRoute: React.FC<{ allowedRoles: Role[]; children: React.ReactNode
     return <>{children}</>;
 };
 
-const Dashboard: React.FC = () => {
+const DashboardRouter: React.FC = () => {
   return (
     <DashboardLayout>
       <Routes>
@@ -68,4 +68,4 @@ const Dashboard: React.FC = () => {
   );
 };
 
-export default Dashboard;
+export default DashboardRouter;

--- a/pages/ForgotPassword.tsx
+++ b/pages/ForgotPassword.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../auth';
+
+const ForgotPasswordPage: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const { sendPasswordResetEmail, state } = useAuth();
+
+  const handlePasswordReset = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLocalError(null);
+    setSuccessMessage(null);
+    if (!email) {
+      setLocalError('Por favor, digite seu e-mail.');
+      return;
+    }
+    try {
+      await sendPasswordResetEmail(email);
+      setSuccessMessage('Se uma conta existir para este e-mail, um link para redefinir a senha foi enviado.');
+    } catch (err: any) {
+      setLocalError(err.message || 'Falha ao enviar o e-mail de redefinição.');
+    }
+  };
+
+  const isFormDisabled = state === 'loading' || !!successMessage;
+
+  return (
+    <div className="auth-forest flex items-center justify-center min-h-screen p-4">
+      <div className="w-full max-w-md p-6 sm:p-8 glass-strong">
+        <div>
+          <h2 className="text-center text-2xl sm:text-3xl font-light text-white font-poppins">
+            Redefinir Senha
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-300">
+            Digite seu email para receber o link de redefinição.
+          </p>
+        </div>
+        <form className="mt-8 space-y-6" onSubmit={handlePasswordReset}>
+          <input
+            id="email-address"
+            name="email"
+            type="email"
+            autoComplete="email"
+            required
+            className="input-glass"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <button type="submit" disabled={isFormDisabled} className="btn btn-primary w-full">
+            {state === 'loading' ? 'Enviando...' : 'Enviar Link de Redefinição'}
+          </button>
+        </form>
+        {localError && <p className="mt-4 text-sm text-red-400 text-center">{localError}</p>}
+        {successMessage && <p className="mt-4 text-sm text-green-400 text-center">{successMessage}</p>}
+        <p className="mt-6 text-center text-sm text-gray-400">
+          Lembrou a senha?{' '}
+          <Link to="/login" className="font-medium text-orange-400 hover:text-orange-300">
+            Voltar para o Login
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -6,134 +6,75 @@ const LoginPage: React.FC = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [localError, setLocalError] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [view, setView] = useState<'login' | 'forgot_password'>('login');
-  
-  const { login, sendPasswordResetEmail, state, error: authError } = useAuth();
+
+  const { login, state, error: authError } = useAuth();
   const navigate = useNavigate();
-  
+
   useEffect(() => {
-    // Redirect if user is already logged in
     if (state === 'authed') {
       navigate('/dashboard', { replace: true });
     }
   }, [state, navigate]);
-  
+
   useEffect(() => {
-      if (authError) {
-          setLocalError(authError);
-      }
+    if (authError) {
+      setLocalError(authError);
+    }
   }, [authError]);
 
-const handleLogin = async (e: React.FormEvent) => {
-  e.preventDefault();
-  setLocalError(null);
-  setSuccessMessage(null);
-
-  try {
-    setSubmitting(true);
-    await login(email, password);                 // faz o sign-in, atualiza o estado e redireciona
-  } catch (err: any) {
-    console.error(err);                           // o AuthProvider já povoa o erro
-  } finally {
-    setSubmitting(false);
-  }
-};
-
-  
-  const handlePasswordReset = async (e: React.FormEvent) => {
+  const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setLocalError(null);
-    setSuccessMessage(null);
-     if (!email) {
-        setLocalError('Por favor, digite seu e-mail.');
-        return;
-    }
+
     try {
-        await sendPasswordResetEmail(email);
-        setSuccessMessage('Se uma conta existir para este e-mail, um link para redefinir a senha foi enviado.');
+      setSubmitting(true);
+      await login(email, password);
     } catch (err: any) {
-        setLocalError(err.message || 'Falha ao enviar o e-mail de redefinição.');
+      console.error(err);
+    } finally {
+      setSubmitting(false);
     }
   };
-
-  const isFormDisabled = submitting || !!successMessage;
-
-  const renderLoginView = () => (
-    <>
-      <div>
-        <h2 className="text-center text-2xl sm:text-3xl font-light text-white font-poppins">
-          Bem-vindo ao <span className="text-orange-500">i2Sales</span>
-        </h2>
-        <p className="mt-2 text-center text-sm text-gray-300">
-          Faça login para continuar
-        </p>
-      </div>
-      <form className="mt-8 space-y-4" onSubmit={handleLogin}>
-        <input
-          id="email-address" name="email" type="email" autoComplete="email" required
-          className="input-glass"
-          placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)}
-        />
-        <input
-          id="password" name="password" type="password" autoComplete="current-password" required
-          className="input-glass"
-          placeholder="Senha" value={password} onChange={(e) => setPassword(e.target.value)}
-        />
-        <div className="flex items-center justify-end text-sm">
-          <button type="button" onClick={() => { setView('forgot_password'); setLocalError(null); setSuccessMessage(null); }} className="font-medium text-orange-400 hover:text-orange-300">
-            Esqueceu a senha?
-          </button>
-        </div>
-        <button type="submit" disabled={isFormDisabled} className="btn btn-primary w-full">
-          {submitting ? 'Entrando...' : 'Entrar'}
-        </button>
-      </form>
-      <p className="mt-6 text-center text-sm text-gray-400">
-        Não tem uma conta?{' '}
-        <Link to="/register" className="font-medium text-orange-400 hover:text-orange-300">
-          Registre-se
-        </Link>
-      </p>
-    </>
-  );
-
-  const renderForgotPasswordView = () => (
-    <>
-      <div>
-        <h2 className="text-center text-2xl sm:text-3xl font-light text-white font-poppins">
-          Redefinir Senha
-        </h2>
-        <p className="mt-2 text-center text-sm text-gray-300">
-          Digite seu email para receber o link de redefinição.
-        </p>
-      </div>
-      <form className="mt-8 space-y-6" onSubmit={handlePasswordReset}>
-        <input
-          id="email-address" name="email" type="email" autoComplete="email" required
-          className="input-glass"
-          placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)}
-        />
-        <button type="submit" disabled={isFormDisabled} className="btn btn-primary w-full">
-          {state === 'loading' ? 'Enviando...' : 'Enviar Link de Redefinição'}
-        </button>
-      </form>
-      <p className="mt-6 text-center text-sm text-gray-400">
-        Lembrou a senha?{' '}
-        <button onClick={() => { setView('login'); setLocalError(null); setSuccessMessage(null); }} className="font-medium text-orange-400 hover:text-orange-300">
-          Voltar para o Login
-        </button>
-      </p>
-    </>
-  );
 
   return (
     <div className="auth-forest flex items-center justify-center min-h-screen p-4">
       <div className="w-full max-w-md p-6 sm:p-8 glass-strong">
-        {view === 'login' ? renderLoginView() : renderForgotPasswordView()}
+        <div>
+          <h2 className="text-center text-2xl sm:text-3xl font-light text-white font-poppins">
+            Bem-vindo ao <span className="text-orange-500">i2Sales</span>
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-300">
+            Faça login para continuar
+          </p>
+        </div>
+        <form className="mt-8 space-y-4" onSubmit={handleLogin}>
+          <input
+            id="email-address" name="email" type="email" autoComplete="email" required
+            className="input-glass"
+            placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)}
+          />
+          <input
+            id="password" name="password" type="password" autoComplete="current-password" required
+            className="input-glass"
+            placeholder="Senha" value={password} onChange={(e) => setPassword(e.target.value)}
+          />
+          <div className="flex items-center justify-end text-sm">
+            <Link to="/forgot-password" className="font-medium text-orange-400 hover:text-orange-300">
+              Esqueceu a senha?
+            </Link>
+          </div>
+          <button type="submit" disabled={submitting} className="btn btn-primary w-full">
+            {submitting ? 'Entrando...' : 'Entrar'}
+          </button>
+        </form>
         {localError && <p className="mt-4 text-sm text-red-400 text-center">{localError}</p>}
-        {successMessage && <p className="mt-4 text-sm text-green-400 text-center">{successMessage}</p>}
+        <p className="mt-6 text-center text-sm text-gray-400">
+          Não tem uma conta?{' '}
+          <Link to="/register" className="font-medium text-orange-400 hover:text-orange-300">
+            Registre-se
+          </Link>
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add dedicated forgot password page and hook it into router
- simplify login page and link to registration and password recovery
- rename dashboard file and centralize broker/manager routing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2212601048330ac2d48cc72ea9b01