### PR TITLE
feat: add authenticated API client and role dashboards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import LoginPage from './pages/Login';
-import DashboardPage from './pages/Dashboard';
+import BrokerDashboard from './pages/BrokerDashboard';
+import ManagerDashboard from './pages/ManagerDashboard';
 import AuthGate from './auth/AuthGate';
 import { AuthProvider } from './auth/useAuth';
 
@@ -15,13 +16,22 @@ const App: React.FC = () => {
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route
-            path="/"
+            path="/broker/dashboard"
             element={
               <AuthGate>
-                <DashboardPage />
+                <BrokerDashboard />
               </AuthGate>
             }
           />
+          <Route
+            path="/manager/dashboard"
+            element={
+              <AuthGate>
+                <ManagerDashboard />
+              </AuthGate>
+            }
+          />
+          <Route path="*" element={<Navigate to="/login" replace />} />
         </Routes>
       </AuthProvider>
     </BrowserRouter>

--- a/src/auth/useAuth.ts
+++ b/src/auth/useAuth.ts
@@ -1,15 +1,24 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabaseClient';
+import { api } from '../services/api';
+
+export type Profile = {
+  id: string;
+  email: string;
+  role: string;
+  name: string;
+};
 
 // Tipos públicos expostos pelo hook/Provider
 type AuthContextValue = {
   user: User | null;
   session: Session | null;
+  profile: Profile | null;
   loading: boolean;
   error: string | null;
-  signUp: (email: string, password: string) => Promise<{ ok: boolean; needsConfirmation?: boolean; error?: string }>; 
-  signIn: (email: string, password: string) => Promise<{ ok: boolean; error?: string }>; 
+  signUp: (email: string, password: string) => Promise<{ ok: boolean; needsConfirmation?: boolean; error?: string }>;
+  signIn: (email: string, password: string) => Promise<{ ok: boolean; error?: string }>;
   signOut: () => Promise<void>;
   refresh: () => Promise<void>;
 };
@@ -37,6 +46,7 @@ function mapAuthError(message?: string | null): string {
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -48,6 +58,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (!mounted) return;
       setSession(data.session ?? null);
       setUser(data.session?.user ?? null);
+      if (data.session) {
+        try {
+          const me = await api<Profile>('/auth/me');
+          setProfile(me);
+        } catch (_) {
+          /* ignore */
+        }
+      }
       setLoading(false);
     })();
 
@@ -55,6 +73,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const { data: sub } = supabase.auth.onAuthStateChange((event, currentSession) => {
       setSession(currentSession);
       setUser(currentSession?.user ?? null);
+      if (currentSession) {
+        api<Profile>('/auth/me')
+          .then(setProfile)
+          .catch(() => setProfile(null));
+      } else {
+        setProfile(null);
+      }
 
       // Eventos úteis para depuração/comportamento
       if (event === 'SIGNED_IN') {
@@ -95,12 +120,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setError(msg);
       return { ok: false, error: msg };
     }
+    try {
+      const me = await api<Profile>('/auth/me');
+      setProfile(me);
+    } catch (_) {
+      /* ignore */
+    }
     return { ok: true };
   }, []);
 
   const signOutFn = useCallback(async () => {
     setError(null);
     await supabase.auth.signOut(); // limpa LocalStorage e estados via listener
+    setProfile(null);
   }, []);
 
   const refresh = useCallback(async () => {
@@ -113,13 +145,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const value = useMemo<AuthContextValue>(() => ({
     user,
     session,
+    profile,
     loading,
     error,
     signUp,
     signIn,
     signOut: signOutFn,
     refresh,
-  }), [user, session, loading, error, signUp, signIn, signOutFn, refresh]);
+  }), [user, session, profile, loading, error, signUp, signIn, signOutFn, refresh]);
 
   return (
     <AuthContext.Provider value={value}>

--- a/src/pages/BrokerDashboard.tsx
+++ b/src/pages/BrokerDashboard.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { useAuth } from '../auth/useAuth';
+import * as clientApi from '../services/clients';
+import * as analyticsApi from '../services/analytics';
+import type { Client } from '../../types';
+
+const BrokerDashboard: React.FC = () => {
+  const { profile } = useAuth();
+  const [clients, setClients] = useState<Client[]>([]);
+  const [kpis, setKpis] = useState<any>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [clientRes, kpiRes] = await Promise.all([
+          clientApi.listClients(),
+          analyticsApi.getBrokerKpis(),
+        ]);
+        setClients(clientRes);
+        setKpis(kpiRes);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="text-2xl mb-4">Broker Dashboard</h1>
+      <p>Olá, {profile?.name}</p>
+      <h2 className="mt-4 font-bold">KPIs</h2>
+      <pre className="bg-black/20 p-2 rounded">{JSON.stringify(kpis, null, 2)}</pre>
+      <h2 className="mt-4 font-bold">Clientes</h2>
+      <pre className="bg-black/20 p-2 rounded">{JSON.stringify(clients, null, 2)}</pre>
+    </div>
+  );
+};
+
+export default BrokerDashboard;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,28 +1,25 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../auth/useAuth';
 
 // Página de Login/Registro combinada com UI minimalista (glassmorphism)
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
-  const location = useLocation();
-  const { signIn, signUp, error, user } = useAuth();
+  const { signIn, signUp, error, profile } = useAuth();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
-  const from = (location.state as any)?.from?.pathname || '/';
-
-  // Se o usuário já estiver autenticado (por exemplo, após o login completar
-  // e o estado global ser atualizado), redireciona para a rota original ou
-  // para a raiz como fallback.
   useEffect(() => {
-    if (user) {
-      navigate(from, { replace: true });
+    if (!profile) return;
+    if (profile.role === 'BROKER') {
+      navigate('/broker/dashboard', { replace: true });
+    } else if (profile.role === 'MANAGER' || profile.role === 'ADMIN') {
+      navigate('/manager/dashboard', { replace: true });
     }
-  }, [user, from, navigate]);
+  }, [profile, navigate]);
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault();

--- a/src/pages/ManagerDashboard.tsx
+++ b/src/pages/ManagerDashboard.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { useAuth } from '../auth/useAuth';
+import * as analyticsApi from '../services/analytics';
+
+const ManagerDashboard: React.FC = () => {
+  const { profile } = useAuth();
+  const [kpis, setKpis] = useState<any>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const today = new Date().toISOString().slice(0, 10);
+        const res = await analyticsApi.getProductivity({ startDate: today, endDate: today });
+        setKpis(res);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="text-2xl mb-4">Manager Dashboard</h1>
+      <p>Olá, {profile?.name}</p>
+      <pre className="bg-black/20 p-2 rounded">{JSON.stringify(kpis, null, 2)}</pre>
+    </div>
+  );
+};
+
+export default ManagerDashboard;

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,0 +1,23 @@
+import { api } from './api';
+
+export const getBrokerKpis = () => api('/analytics/broker-kpis');
+
+export interface ProductivityParams {
+  startDate: string;
+  endDate: string;
+  brokerId?: string;
+}
+
+export const getProductivity = (params: ProductivityParams) => {
+  const search = new URLSearchParams({ startDate: params.startDate, endDate: params.endDate });
+  if (params.brokerId) search.set('brokerId', params.brokerId);
+  return api(`/analytics/productivity?${search.toString()}`);
+};
+
+export const getFunnel = (params: Record<string, string | undefined>) => {
+  const search = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v) search.set(k, v);
+  }
+  return api(`/analytics/funnel?${search.toString()}`);
+};

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,39 @@
+import { supabase } from '../lib/supabaseClient';
+
+const BASE_URL =
+  (import.meta.env.VITE_API_BASE_URL as string | undefined) ||
+  'http://localhost:5000/api/v1';
+
+export class ApiError extends Error {
+  status: number;
+  data: any;
+  constructor(message: string, status: number, data: any) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.data = data;
+  }
+}
+
+export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const { data: { session } } = await supabase.auth.getSession();
+  const headers = new Headers(init.headers || {});
+  if (!(init.body instanceof FormData)) {
+    headers.set('Content-Type', 'application/json');
+  }
+  if (session?.access_token) {
+    headers.set('Authorization', `Bearer ${session.access_token}`);
+  }
+  const res = await fetch(`${BASE_URL}${path}`, { ...init, headers });
+  let data: any = null;
+  try {
+    data = await res.json();
+  } catch (_) {
+    /* ignore */
+  }
+  if (!res.ok) {
+    const message = data?.error || res.statusText;
+    throw new ApiError(message, res.status, data);
+  }
+  return data as T;
+}

--- a/src/services/clients.ts
+++ b/src/services/clients.ts
@@ -1,0 +1,47 @@
+import { api } from './api';
+import type { Client } from '../../types';
+import { parseCurrency } from '../../utils/helpers';
+
+export async function listClients(q?: string): Promise<Client[]> {
+  const params = q ? `?q=${encodeURIComponent(q)}` : '';
+  return api<Client[]>(`/clients${params}`);
+}
+
+export const getClient = (id: string): Promise<Client> => {
+  return api<Client>(`/clients/${id}`);
+};
+
+export interface ClientPayload {
+  name: string;
+  phone: string;
+  source: string;
+  status?: string;
+  followUpState?: string;
+  email?: string;
+  observations?: string;
+  product?: string;
+  propertyValue?: string | number | null;
+}
+
+export async function createClient(payload: ClientPayload): Promise<Client> {
+  const propertyValue = parseCurrency(payload.propertyValue ?? undefined);
+  return api<Client>('/clients', {
+    method: 'POST',
+    body: JSON.stringify({ ...payload, propertyValue }),
+  });
+}
+
+export async function updateClient(id: string, payload: Partial<ClientPayload>): Promise<Client> {
+  const body: any = { ...payload };
+  if (payload.propertyValue !== undefined) {
+    body.propertyValue = parseCurrency(payload.propertyValue);
+  }
+  return api<Client>(`/clients/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  });
+}
+
+export const deleteClient = (id: string): Promise<void> => {
+  return api<void>(`/clients/${id}`, { method: 'DELETE' });
+};

--- a/src/services/interactions.ts
+++ b/src/services/interactions.ts
@@ -1,0 +1,16 @@
+import { api } from './api';
+import type { Interaction } from '../../types';
+
+export interface InteractionPayload {
+  clientId: string;
+  type: string;
+  observation?: string;
+  explicitNext?: string;
+}
+
+export const createInteraction = (payload: InteractionPayload): Promise<Interaction> => {
+  return api<Interaction>('/interactions', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+};


### PR DESCRIPTION
## Summary
- add api helper to automatically send Supabase JWT
- fetch user profile and redirect by role after login
- scaffold broker and manager dashboards with basic data loading

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2274e98a883309eefb559315f6dbd